### PR TITLE
BUG: Didn't trigger cancellation of membership

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -169,6 +169,7 @@ function pmprowoo_cancel_membership_from_order($order_id)
 add_action("woocommerce_order_status_refunded", "pmprowoo_cancel_membership_from_order");
 add_action("woocommerce_order_status_failed", "pmprowoo_cancel_membership_from_order");
 add_action("woocommerce_order_status_on_hold", "pmprowoo_cancel_membership_from_order");
+add_action("woocommerce_order_status_cancelled", "pmprowoo_cancel_membership_from_order");
 
 /*
 	Activate memberships when WooCommerce subscriptions change status.


### PR DESCRIPTION
Didn't process the membership cancellation since the woocommerce_order_status_cancelled action wasn't hooked.
