### PR TITLE
BUG: Updated use of deprecated function WC_Subscriptions_Manager::get…

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -185,7 +185,7 @@ function pmprowoo_activated_subscription($user_id, $subscription_key)
     /*
         does this order contain a membership product?
     */
-    $subscription = WC_Subscriptions_Manager::get_users_subscription( $user_id, $subscription_key );
+    $subscription = WC_Subscriptions_Manager::get_subscription( $subscription_key );
     if ( isset( $subscription['product_id'] ) && isset( $subscription['order_id'] ) )
     {
         $product_id = $subscription['product_id'];
@@ -226,7 +226,7 @@ function pmprowoo_cancelled_subscription($user_id, $subscription_key)
     /*
         does this order contain a membership product?
     */
-    $subscription = WC_Subscriptions_Manager::get_users_subscription( $user_id, $subscription_key );
+    $subscription = WC_Subscriptions_Manager::get_subscription( $subscription_key );
     if ( isset( $subscription['product_id'] ) && isset( $subscription['order_id'] ) )
     {
         $product_id = $subscription['product_id'];


### PR DESCRIPTION
…_users_subscription() that resulted in fatal error. WC_Subscriptions_Manager::get_users_subscription() was deprecated in v1.4 are removed in v2.1. Using WC_Subscriptions_Manager::get_subscription() instead.