### PR TITLE
BUG FIX: Checkbox ignored saved value

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -407,9 +407,8 @@ function pmprowoo_tab_options() {
                         array(
                         'id'      => '_membership_product_autocomplete',
                         'label'   => __( 'Autocomplete Order Status', 'pmpro-woocommerce' ),
-						'description' => __( "Check this to mark the order as completed immediately after checkout to activate the associated membership.", 'pmpro-woocommerce' ),
-						'cbvalue' => 1,
-						)
+			'description' => __( "Check this to mark the order as completed immediately after checkout to activate the associated membership.", 'pmpro-woocommerce' ),
+			)
                     );
                 ?>
             </p>


### PR DESCRIPTION
The "Autocomplete Order Status" checkbox on the "Memberships" Tab of the Products page in WooCommerce would ignore change to the saved status once the checkbox had been selected once.