### PR TITLE
BUG FIX: Deactivating 'autocomplete' didn't work

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -496,7 +496,6 @@ function pmprowoo_tab_options() {
 						'id'          => '_membership_product_autocomplete',
 						'label'       => __( 'Autocomplete Order Status', 'pmpro-woocommerce' ),
 						'description' => __( "Check this to mark the order as completed immediately after checkout to activate the associated membership.", 'pmpro-woocommerce' ),
-						'cbvalue'     => 1,
 					)
 				);
 				?>


### PR DESCRIPTION
Deactivating the "Autocomplete order" checkbox for "Memberships" didn't save the new state (unchecked)