### PR TITLE
Fix: Get User ID on imported subscriptions

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -287,9 +287,7 @@ function pmprowoo_activated_subscription( $subscription ) {
 		Since v2 of WCSubs, we need to check all line items
 	*/
 	$order_id = $subscription->get_last_order();
-	$order    = wc_get_order( $order_id );
-	$items    = $order->get_items();
-	$user_id  = $order->get_user_id();
+	$user_id = $subscription->get_user_id();
 	
 	if ( ! empty( $items ) && ! empty( $user_id ) ) {
 		//membership product ids
@@ -332,9 +330,7 @@ function pmprowoo_cancelled_subscription( $subscription ) {
 		Since v2 of WCSubs, we need to check all line items
 	*/
 	$order_id = $subscription->get_last_order();
-	$order    = wc_get_order( $order_id );
-	$items    = $order->get_items();
-	$user_id  = $order->get_user_id();
+	$user_id = $subscription->get_user_id();
 	
 	if ( ! empty( $items ) && ! empty( $user_id ) ) {
 		//membership product ids


### PR DESCRIPTION
Imported Subscriptions don't have an initial order until they renew for the first time but if they are changed to On-Hold and then Active again an error is thrown with current method for get_user_id.