### PR TITLE
FIX: properly retrieving value of "Apply Member Discounts to WC Subscription Products?" admin setting

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -47,7 +47,7 @@ function pmprowoo_init() {
 	
 	// Apply Discounts to Subscriptions
 	global $pmprowoo_discounts_on_subscriptions;
-	$pmprowoo_discounts_on_subscriptions = get_option( 'pmprowoo_discounts_on_subscriptions' );
+	$pmprowoo_discounts_on_subscriptions = pmpro_getOption( 'pmprowoo_discounts_on_subscriptions' );
 	if ( empty( $pmprowoo_discounts_on_subscriptions ) ) {
 		$pmprowoo_discounts_on_subscriptions = false;
 	}


### PR DESCRIPTION
saving using `pmpro_setOption()` and retrieving using `get_option()`, so pmprowoo_discounts_on_subscriptions is always false because DB options entry is prefixed with `pmpro_`

fixes #105