### PR TITLE
Membership prices now handle different decimal separators

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -602,8 +602,9 @@ function pmprowoo_process_product_meta() {
 		update_option( '_pmprowoo_product_levels', $pmprowoo_product_levels );
 		
 		// Save each membership level price
+		$decimal_separator = wc_get_price_decimal_separator();
 		foreach ( $membership_levels as $level ) {
-			$price = $_POST[ '_level_' . $level->id . "_price" ];
+			$price = str_replace( $decimal_separator, '.', $_POST[ '_level_' . $level->id . "_price" ] );
 			update_post_meta( $post_id, '_level_' . $level->id . '_price', $price );
 		}
 	}


### PR DESCRIPTION
To replicate issue:
1. Set "Decimal separator" in WooCommerce to be `,` or any character besides `.`
2. Add a membership price to a product that is not a whole number (ie. `15,95`)
3. Save product
4. View product page on site frontend
5. See that the decimal part of number is left off (would show `15,00`)

This is because we were saving the price in the database with the custom decimal separator, whereas WooCommerce always saves prices in the database with `.` as the decimal separator, regardless of the custom separator set. This change makes our Membership Prices save more similarly to WC prices.