### PR TITLE
Discounts apply to the variation product and not the parent

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -438,7 +438,11 @@ function pmprowoo_get_membership_price( $price, $product ) {
 	
 	// use this level to get the price
 	if ( isset( $level_price ) ) {
-		$product_id = $product->get_id();
+		if( $product->get_type() === 'variation' ){
+			$product_id = $product->get_parent_id(); //for variations	
+		} else {
+			$product_id = $product->get_id();
+		}
 		$level_price = get_post_meta( $product_id, $level_price, true );
 		if ( ! empty( $level_price ) || $level_price === '0' || $level_price === '0.00' || $level_price === '0,00' ) {
 			$discount_price = $level_price;


### PR DESCRIPTION
How to replicate the issue: 

- Create a variable product
- Set the Member discount to the product to $0
- Add a variation to your cart
- Discount won't be applied

This is because we use the product ID and that then references the variable item instead of the parent. 

This PR then uses the parent ID instead because we save the discount values to the ID. 

Long term we should maybe consider adding support for discounts for each variation too.