### PR TITLE
pmprowoo_user_has_active_membership_product_for_level() now looks for pending-cancel status

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,7 +76,7 @@ function pmprowoo_user_has_active_membership_product_for_level( $user_id, $level
 				$product = get_product( $product_id );
 				if ( ! empty( $product ) && is_object( $product ) && method_exists( $product, 'is_type' ) ) {
 					if ( $product->is_type( 'subscription' ) ) {
-						if ( function_exists( 'wcs_user_has_subscription' ) && wcs_user_has_subscription( $user_id, $product_id, 'active' ) ) {
+						if ( function_exists( 'wcs_user_has_subscription' ) && wcs_user_has_subscription( $user_id, $product_id, array( 'active', 'pending-cancel' ) ) ) {
 							return true;
 						}
 					} else {


### PR DESCRIPTION
WC subscription orders in `pending-cancel` status are still active subscriptions, though they will be fully cancelled at the end of the current payment period. As such, PMPro users should keep their membership level if their subscription is in `pending-cancel` status.

Original ticket (demonstrates strange behavior that can occur without this fix): https://www.paidmembershipspro.com/forums/topic/problem-with-membership-reset/