### PR TITLE
Checks for an empty value before calculating discount

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -662,7 +662,7 @@ function pmprowoo_save_membership_level( $level_id ) {
 	global $pmprowoo_member_discounts;
 	
 	//convert % to decimal
-	$member_discount = ( isset($_POST['membership_discount']) ? sanitize_text_field( $_POST['membership_discount'] ) : 0 )/100;
+	$member_discount = ! empty( $_POST['membership_discount'] ) ? ( (float) sanitize_text_field( $_POST['membership_discount'] ) / 100 ) : 0;
 	$pmprowoo_member_discounts[$level_id] = $member_discount;
 	update_option( '_pmprowoo_member_discounts', $pmprowoo_member_discounts );
 }


### PR DESCRIPTION
Related to #134 

We now check if there's a value present and if not, set it to 0. 