### PR TITLE
Remove membership level when Woo order is On Hold

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -257,6 +257,8 @@ add_action( "woocommerce_order_status_refunded", "pmprowoo_cancel_membership_fro
 add_action( "woocommerce_order_status_failed", "pmprowoo_cancel_membership_from_order" );
 add_action( 'woocommerce_subscription_status_on-hold_to_active', 'pmprowoo_activated_subscription' );
 add_action( "woocommerce_order_status_cancelled", "pmprowoo_cancel_membership_from_order" );
+add_action( 'woocommerce_order_status_on-hold', 'pmprowoo_cancel_membership_from_order' );
+add_action( "woocommerce_subscription_status_on-hold", "pmprowoo_cancel_membership_from_order" );
 
 /**
  * Activate memberships when WooCommerce subscriptions change status.


### PR DESCRIPTION
Removes access when a Woo order is changed to the On Hold status .

Resolves #106

To Test: 

- Purchase a product that has a level associated with it. 
- After the order has been marked as complete, edit it and change it to On Hold
- The membership level should be removed from the user's profile.