### PR TITLE
Removed an undefined variable

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -364,7 +364,7 @@ function pmprowoo_cancelled_subscription( $subscription ) {
 				//check if another active subscription exists
 				if (  ! pmprowoo_user_has_active_membership_product_for_level( $user_id, $pmprowoo_product_levels[ $item['product_id'] ] ) ) {	
 					//is there a membership level for this product?
-					if( !$has_sub && in_array($item['product_id'], $membership_product_ids) ){
+					if( in_array($item['product_id'], $membership_product_ids) ){
 						//remove the user from the level
 						pmpro_cancelMembershipLevel($pmprowoo_product_levels[$item['product_id']], $user_id);
 					}


### PR DESCRIPTION
Use of $has_sub is not defined anywhere in the function. Might have been a copy/paste error while moving the function into an if statement. 

Resolves #170 

Steps to recreate: 

1. Enable debug loggins
2. Ensure that the user has a membership level that is associated with a subscription in Woo
3. Cancel the subscription
4. No error should be reported anymore