### PR TITLE
Avoid fatal error: Uncaught Error: Call to a member function get_id() on bool

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -850,6 +850,10 @@ function pmprowoo_order_autocomplete( $order_id ) {
 			if ( $item['type'] == 'line_item' ) {
 				//get product info and check if product is marked to autocomplete
 				$_product = $item->get_product();
+				if( ! $_product instanceof \WC_Product ) {
+					continue;
+				}
+
 				$product_id = $_product->get_id();
 				$product_autocomplete = get_post_meta( $product_id, '_membership_product_autocomplete', true );
 				


### PR DESCRIPTION
$_product can be false. This is because the ->get_product() has these return types: \WC_Product|false. Then we should check if $_product instanceof \WC_Product or continue;

Cases:
- Order with an empty line
- Plugins which permit to buy (in WC cart) items (CPT) which are NOT extending the \WC_Product class.
- Order with a raw line_item
