### PR TITLE
Fix Woo Subs Renewal Restart

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -157,9 +157,9 @@ function pmprowoo_add_membership_from_order( $order_id ) {
 			     in_array( $product_id, $membership_product_ids ) ) {    //not sure when a product has id 0, but the Woo code checks this
 				
 				// Check to see if the order is a renewal order for a subscription. If it is, bail.
-				if ( class_exists( 'WC_Subscriptions_Renewal_Order' ) ) {
+					if ( function_exists( 'wcs_order_contains_renewal' ) ) {
 					// If the user already has the level, let's just leave it and assume it's a renewal order.
-					if ( WC_Subscriptions_Renewal_Order::is_renewal( $order_id ) ) {
+					if ( wcs_order_contains_renewal( $order )  ) {
 						if ( pmprowoo_user_has_active_membership_product_for_level( $user_id, $pmprowoo_product_levels[ $product_id ] ) ) {
 							return;
 						}

--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -155,7 +155,17 @@ function pmprowoo_add_membership_from_order( $order_id ) {
 
 			if ( ! empty( $product_id ) &&
 			     in_array( $product_id, $membership_product_ids ) ) {    //not sure when a product has id 0, but the Woo code checks this
-			
+				
+				// Check to see if the order is a renewal order for a subscription. If it is, bail.
+				if ( class_exists( 'WC_Subscriptions_Renewal_Order' ) ) {
+					// If the user already has the level, let's just leave it and assume it's a renewal order.
+					if ( WC_Subscriptions_Renewal_Order::is_renewal( $order_id ) ) {
+						if ( pmprowoo_user_has_active_membership_product_for_level( $user_id, $pmprowoo_product_levels[ $product_id ] ) ) {
+							return;
+						}
+					}
+				}
+				
 				//is there a membership level for this product?
 				//get user id and level
 				$pmpro_level = pmpro_getLevel( $pmprowoo_product_levels[ $product_id ] );


### PR DESCRIPTION
* BUG FIX: Stop WooCommerce Subscription renewal orders from restarting the members level for each order.

Resolves [#188](https://github.com/strangerstudios/pmpro-woocommerce/issues/188).

### How to test the changes in this Pull Request:

1. Create a WooCommerce Subscription Product tied to a membership level. Buy it.
2. Navigate to WooCommerce > Status > Scheduled Actions and search for the subscription ID and run the scheduler to process the subscription.
3. A new WooCommerce order is created, be sure to mark it as completed and notice that the user's current level wouldn't change or reset in Member History section.

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?

