### PR TITLE
FIX: Discounting incorrectly for variation subscriptions

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -438,7 +438,7 @@ function pmprowoo_get_membership_price( $price, $product ) {
 	$items       = is_object( WC()->cart ) ? WC()->cart->get_cart_contents() : array(); // items in the cart
 
 	//ignore membership products and subscriptions if we are set that way
-	if ( ( ! $pmprowoo_discounts_on_subscriptions || $pmprowoo_discounts_on_subscriptions == 'No' ) && ( $product->get_type() == "subscription" || $product->get_type() == "variable-subscription" || in_array( $product_id, $membership_product_ids, false ) ) ) {
+	if ( ( ! $pmprowoo_discounts_on_subscriptions || $pmprowoo_discounts_on_subscriptions == 'No' ) && ( $product->is_type( array( 'subscription', 'variable-subscription', 'subscription_variation' ) ) || in_array( $product_id, $membership_product_ids, false ) ) ) {
 		return $price;
 	}
 


### PR DESCRIPTION
* BUG FIX: Fixed an issue where variation subscriptions were being discounted incorrectly.

Resolves: https://github.com/strangerstudios/pmpro-woocommerce/issues/187

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?