### PR TITLE
Show a different message for viewing same product that's in the cart

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -99,7 +99,8 @@ add_filter( 'woocommerce_is_purchasable', 'pmprowoo_is_purchasable', 10, 2 );
  */
 function pmprowoo_purchase_disabled() {
 	$cart_url = wc_get_cart_url();
-	$product_id = wc_get_product()->get_id();
+	$product = wc_get_product();
+	$product_id = $product->get_id();
 
 	// Get cart contents and see if they're a membership product
 	$membership_products_in_cart = pmprowoo_get_memberships_from_cart();
@@ -111,7 +112,8 @@ function pmprowoo_purchase_disabled() {
 				sprintf( '<a href="%1$s" title="%2$s">', esc_url( $cart_url ), esc_html__( 'Cart', 'pmpro-woocommerce' ) ),
 				'</a>' );
 	} else {
-		$message = sprintf( __( "You have added this membership product to your %scart%s. Complete your purchase to activate your membership.", 'pmpro-woocommerce' ),
+		$message = sprintf( __( "%s is already in your %scart%s.", 'pmpro-woocommerce' ),
+				$product->get_name(),
 				sprintf( '<a href="%1$s" title="%2$s">', esc_url( $cart_url ), esc_html__( 'Cart', 'pmpro-woocommerce' ) ),
 				'</a>' );
 	}

--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -932,6 +932,7 @@ add_filter( 'woocommerce_order_status_processing', 'pmprowoo_order_autocomplete'
 
 /**
  * Get products that are in the cart that are attached to a level ID.
+ * Return product ID's of membership level products in the cart.
  *
  * @return array $levels The products and levels.
  */
@@ -939,7 +940,7 @@ function pmprowoo_get_memberships_from_cart() {
 	global $woocommerce, $pmprowoo_product_levels;
 
 	$membership_product_ids = array_keys( $pmprowoo_product_levels );
-	$cart_items  = $woocommerce->cart->cart_contents; // items in the cart
+	$cart_items  = $woocommerce->cart->cart_contents;
 	$membership_product_ids_in_cart = array();
 	
 	// Nothing in the cart, just bail.
@@ -947,13 +948,13 @@ function pmprowoo_get_memberships_from_cart() {
 		return $membership_product_ids_in_cart;
 	}
 
-
+	// Get all product IDs in the cart
 	$product_ids = array();
 	foreach( $cart_items as $item ) {
 		$product_ids[] = $item['product_id'];
 	}
 
-	// Compare values between the two arrays and show all overlapping values
+	// Compare values between the two arrays of membership products and items in the cart.
 	$membership_product_ids_in_cart = array_values( array_intersect( $membership_product_ids, $product_ids ) );
 
 	return $membership_product_ids_in_cart;


### PR DESCRIPTION
* ENHANCEMENT: Show a different message when the item in the cart is for the level you are looking at.

This shows a different message when viewing a membership linked product that is already in your cart, to make things clearer. It doesn't compare levels linked to the product itself but as long as it's a level linked product we show a different message.

Resolves: https://github.com/strangerstudios/pmpro-woocommerce/issues/81

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?