### PR TITLE
Update headings hierarchy for a11y

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -4,7 +4,7 @@
     content: "\f307";
 }
 
-.pmprowoo_options_group-membership_product h3,
-.pmprowoo_options_group-membership_discount h3 {
+.pmprowoo_options_group-membership_product h2,
+.pmprowoo_options_group-membership_discount h2 {
 	padding: 0 12px;
 }

--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -566,7 +566,7 @@ function pmprowoo_tab_options() {
     <div id="pmprowoo_tab_data" class="panel woocommerce_options_panel">
 
 		<div class="options_group pmprowoo_options_group-membership_product">
-			<h3><?php esc_html_e( 'Give Customers a Membership Level', 'pmpro-woocommerce' ); ?></h3>
+			<h2><?php esc_html_e( 'Give Customers a Membership Level', 'pmpro-woocommerce' ); ?></h2>
 			<?php
 			// Membership Product
 			// woocommerce_wp_select() escapes attributes for us.
@@ -600,7 +600,7 @@ function pmprowoo_tab_options() {
 			?>
         </div> <!-- end pmprowoo_options_group-membership_product -->
 		<div class="options-group pmprowoo_options_group-membership_discount">
-			<h3><?php esc_html_e( 'Member Discount Pricing', 'pmpro-woocommerce' ); ?></h3>
+			<h2><?php esc_html_e( 'Member Discount Pricing', 'pmpro-woocommerce' ); ?></h2>
 			<p><?php printf( __( 'Set the custom price based on Membership Level. <a href="%s">Edit your membership levels</a> to set a global percent discount for all products.', 'pmpro-woocommerce' ), esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) ) ); ?></p>
             <?php
 			// For each membership level, create respective price field


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.