### PR TITLE
Fix filter archives issue

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -985,8 +985,9 @@ add_action( 'before_woocommerce_init', 'pmprowoo_compatible_for_hpos' );
  * @since TBD
  */
 function pmprowoo_remove_pmpro_filtering_archives() {
+
 	// Don't do anything if we're not on a product archive page
-	if ( ! is_product_category() ) {
+	if ( ! function_exists( 'is_product_category' ) || ! is_product_category() ) {
 		return;
 	}
 

--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -979,3 +979,19 @@ function pmprowoo_compatible_for_hpos() {
 	}
 }
 add_action( 'before_woocommerce_init', 'pmprowoo_compatible_for_hpos' );
+
+/**
+ * Remove content restriction for certain cases.
+ * @since TBD
+ */
+function pmprowoo_remove_pmpro_filtering_archives() {
+	// Don't do anything if we're not on a product archive page
+	if ( ! is_product_category() ) {
+		return;
+	}
+
+	// Just always remove this hook when on the category page.
+	remove_filter( 'pre_get_posts', 'pmpro_search_filter' );
+
+}
+add_action( 'pre_get_posts', 'pmprowoo_remove_pmpro_filtering_archives', 5 );


### PR DESCRIPTION
* BUG FIX: Fixes an issue where the "Filter Searches and Archives" option would hide products from their category pages.

Note: This would only happen when post categories would have the same name and slug from posts.

Resolves: https://github.com/strangerstudios/pmpro-woocommerce/issues/195

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?