### PR TITLE
Fix cancellations not working on Variable Subscriptions

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -75,7 +75,7 @@ function pmprowoo_user_has_active_membership_product_for_level( $user_id, $level
 			if ( intval( $level_id ) === intval( $product_level_id ) ) {
 				$product = get_product( $product_id );
 				if ( ! empty( $product ) && is_object( $product ) && method_exists( $product, 'is_type' ) ) {
-					if ( $product->is_type( 'subscription' ) ) {
+					if ( $product->is_type( array( 'subscription', 'variable-subscription', 'subscription_variation' ) ) ) {
 						if ( function_exists( 'wcs_user_has_subscription' ) && wcs_user_has_subscription( $user_id, $product_id, array( 'active', 'pending-cancel' ) ) ) {
 							return true;
 						}


### PR DESCRIPTION
* BUG FIX: Fixed an issue where cancelling a variable subscription wouldn't remove the membership level from the user.

This will remove the level upon cancelling immediately.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Create a variation subscription with 2 or more variations.
2. Set this product to assign a membership level ID when purchased.
3. Checkout for this product, if the order doesn't autocomplete or you're on local be sure to mark the order as successful/completed.
4. Cancel your subscription for this product
5. See that the customer's membership level was removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
