### PR TITLE
Added PMPro v3.0 compatibility.

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -83,10 +83,41 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 
 	$has_membership = pmprowoo_cart_has_membership();
 	$product_id     = $product->get_id();
-	$is_purchasable = ( in_array( $product_id, array_keys( $pmprowoo_product_levels ) ) && true === $has_membership ? false : $is_purchasable );
+
+	// Backwards compatibility for pre 3.0 versions of PMPro.
+	if ( version_compare( 'PMPRO_VERSION', '3.0.0', '<' ) ) {
+		$is_purchasable = ( in_array( $product_id, array_keys( $pmprowoo_product_levels ) ) && true === $has_membership ? false : $is_purchasable ); // Check if the product is in the cart
+		if ( ! $is_purchasable ) {
+			add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
+		}
+		return $is_purchasable;
+	}
 	
+	$level_groups_in_cart = pmprowoo_get_level_groups_in_cart();
+
+	// Compare group ID of product with the one in the cart.
+	if ( $level_groups_in_cart ) {
+		$group_id = pmpro_get_group_id_for_level( $pmprowoo_product_levels[ $product_id ] );
+		if ( ! empty( $group_id ) ) {
+			// Get the group
+			$group = pmpro_get_level_group( $group_id );
+
+			// If the level group is in the cart already, let's make sure it the product viewing allows multiple levels at once.
+			if ( array_key_exists( $group_id, $level_groups_in_cart ) ) {	
+				$allowed_multiples = (bool) $group->allow_multiple_selections; // product allows multiples or not.
+				if ( $allowed_multiples ) {
+					$is_purchasable = true;
+				} elseif ( ! $allowed_multiples && $has_membership ) {
+					$is_purchasable = false;
+				}
+			} else {
+				$is_purchasable = true; // Groups not in the cart let's override the check.
+			}
+		} 
+	}
+
+	// Add the warning message for the single product summary page(s)
 	if ( false === $is_purchasable ) {
-		// Add the warning message for the single product summary page(s)
 		add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
 	}
 	
@@ -94,6 +125,33 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 }
 add_filter( 'woocommerce_is_purchasable', 'pmprowoo_is_purchasable', 10, 2 );
 
+/**
+ * Get the levels groups for membership products in the cart.
+ *
+ * @return array|bool $group_ids This will return false if no products are in the cart or an array of group ID's and whether they allow multiple levels.
+ */
+function pmprowoo_get_level_groups_in_cart() {
+	global $pmprowoo_product_levels;
+
+	$products_in_cart = pmprowoo_get_memberships_from_cart();
+
+	// No products in the cart.
+	if ( empty( $products_in_cart ) ) {
+		return false;
+	}
+
+	// Loop through products and return group ID's
+	$group_ids = array();
+	foreach ( $products_in_cart as $product_id ) {
+		$group_id = pmpro_get_group_id_for_level( $pmprowoo_product_levels[$product_id] );
+		if ( ! empty( $group_id ) ) {
+			// Get the group
+			$group = pmpro_get_level_group( $group_id );
+			$group_ids[$group_id] = (bool) $group->allow_multiple_selections;
+		}
+	}
+	return $group_ids;
+}
 /**
  * Info message when attempting to add a 2nd membership level to the cart
  */
@@ -425,7 +483,7 @@ add_action( 'woocommerce_scheduled_subscription_end_of_prepaid_term', 'pmprowoo_
  */
 function pmprowoo_get_membership_price( $price, $product ) {
 	global $current_user, $pmprowoo_member_discounts, $pmprowoo_product_levels, $pmprowoo_discounts_on_subscriptions;
-	
+
 	// quitely exit if PMPro isn't active
 	if ( ! defined( 'PMPRO_DIR' ) && ! function_exists( 'pmpro_init' ) ) {
 		return $price;


### PR DESCRIPTION
* ENHANCEMENT: Added functionality to detect if level groups allow single or multiple levels and make the products available for checkout within a single cart.

For example if level 1 is in group 1 and group 1 only allows one level per group you may only add one to your cart per checkout. If you have a level that belongs to a group with multiple levels, you may add as many products as you'd like within this group.