### PR TITLE
Fix subscription on hold resetting membership

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -330,7 +330,6 @@ function pmprowoo_cancel_membership_from_order( $order_id ) {
 }
 add_action( "woocommerce_order_status_refunded", "pmprowoo_cancel_membership_from_order" );
 add_action( "woocommerce_order_status_failed", "pmprowoo_cancel_membership_from_order" );
-add_action( 'woocommerce_subscription_status_on-hold_to_active', 'pmprowoo_activated_subscription' );
 add_action( "woocommerce_order_status_cancelled", "pmprowoo_cancel_membership_from_order" );
 
 /**
@@ -453,7 +452,7 @@ function pmprowoo_cancelled_subscription( $subscription ) {
 add_action( 'woocommerce_subscription_status_cancelled', 'pmprowoo_cancelled_subscription', 10 );
 add_action( 'woocommerce_subscription_status_trash', 'pmprowoo_cancelled_subscription', 10 );
 add_action( 'woocommerce_subscription_status_expired', 'pmprowoo_cancelled_subscription', 10 );
-add_action( 'woocommerce_subscription_status_on-hold', 'pmprowoo_cancelled_subscription', 10 );
+// add_action( 'woocommerce_subscription_status_on-hold', 'pmprowoo_cancelled_subscription', 10 );
 add_action( 'woocommerce_scheduled_subscription_end_of_prepaid_term', 'pmprowoo_cancelled_subscription', 10 );
 
 /**


### PR DESCRIPTION
* BUG FIX: Fixed an issue where subscriptions would reset (remove and readd) the user's membership level.

* REFACTOR: Cleaned up duplicate hooks that were called.

Resolves: https://github.com/strangerstudios/pmpro-woocommerce/issues/201

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?