### PR TITLE
[POC] Fix false warnings for the is_purchase on cart page

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -91,8 +91,14 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 	if ( ! function_exists( 'pmpro_get_group_id_for_level' ) ) {
 		// If the cart already has a membership product, let's disable the purchase.
 		if ( pmprowoo_cart_has_membership() ) {
-			add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
-			return false;
+			// If we're on the cart page let's just return the $is_purchasable status and otherwise lets show a warning that there's already a membership in the cart.
+			if ( is_cart() || is_checkout() ) {
+				return $is_purchasable;
+			} else {
+				add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
+				return false;
+			}
+			
 		}
 		return $is_purchasable;
 	}
@@ -126,8 +132,12 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 
 		// If the group ID in the cart matches the group ID of the product we are viewing, let's disable the purchase.
 		if ( (int)$group_id_in_cart === (int)$group_id ) {
-			add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
-			return false;
+			if ( is_cart() || is_checkout() ) {
+				return $is_purchasable;
+			} else {
+				add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
+				return false;
+			}
 		}
 	}
 	


### PR DESCRIPTION
* BUG FIX: Fixed a false warning when you had the product in your cart page and viewed the cart page.

I think it may be better to figure out this in the `pmprowoo_cart_has_membership()` has more than one membership level in the cart when on the cart or checkout page and doesn't allow multiple checkouts in the group settings.

The logic here would assume if we make it to the checkout or cart page that things are okay because it seems that the logic checks this more than once while on the cart page causing the false positive. I do think we need a special check for when viewing the cart or checkout page and making sure all the products are still purchasable.

This is a proof of concept for now and may not fully function correctly in some cases but it is a good starting point.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?