### PR TITLE
Fix purchasing levels from single level group

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -118,6 +118,11 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 			continue;
 		}
 
+		// If the cart product is the same as the product passed into this function, continue.
+		if ( $product_id === $product->get_id() ) {
+			continue;
+		}
+
 		// Get the group ID for the product in the cart.
 		$group_id_in_cart = pmpro_get_group_id_for_level( $pmprowoo_product_levels[ $product_id ] );
 		if ( empty( $group_id_in_cart ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Throughout a WC checkout flow, the `woocommerce_is_purchasable` filter is used to determine whether each product in a cart can be purchased. For PMPro level groups that only allow users to have one level for the group, we use that filter to ensure that the user is not trying to purchase multiple levels from that group at once.

Before this PR, there was an issue that whenever a level from  "single level group" was in the cart, it would check if there are any other levels in the cart, see itself, and say "oops, we can't purchase this!"

This PR updates the logic so that products ignore themselves while checking if other levels from the same group are being purchased.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
