### PR TITLE
Fix false warnings

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -91,8 +91,14 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 	if ( ! function_exists( 'pmpro_get_group_id_for_level' ) ) {
 		// If the cart already has a membership product, let's disable the purchase.
 		if ( pmprowoo_cart_has_membership() ) {
-			add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
-			return false;
+			// If we're on the cart page let's just return the $is_purchasable status and otherwise lets show a warning that there's already a membership in the cart.
+			if ( is_cart() || is_checkout() ) {
+				return $is_purchasable;
+			} else {
+				add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
+				return false;
+			}
+			
 		}
 		return $is_purchasable;
 	}
@@ -126,8 +132,12 @@ function pmprowoo_is_purchasable( $is_purchasable, $product ) {
 
 		// If the group ID in the cart matches the group ID of the product we are viewing, let's disable the purchase.
 		if ( (int)$group_id_in_cart === (int)$group_id ) {
-			add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
-			return false;
+			if ( is_cart() || is_checkout() ) {
+				return $is_purchasable;
+			} else {
+				add_action( 'woocommerce_single_product_summary', 'pmprowoo_purchase_disabled' );
+				return false;
+			}
 		}
 	}
 	


### PR DESCRIPTION
* BUG FIX: Fixes a bug where products that can only be purchased one per cart would incorrectly not allowed to be purchased even if it was the only membership product in the cart.

Hooking into `wp` allows us to use the `is_cart` and `is_checkout` functions from WooCommerce to avoid this error. Admins/Shop Owners should also limit purchases for products that should only be purchased one per cart within the "inventory" settings of WooCommerce.

For some reason the 'is_purchasable' was running multiple times on the checkout and cart page due to our updated code.

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?