### PR TITLE
Two strings in pmpro-gift-levels.php can now be localized

### DIFF
--- a/includes/pmpro-gift-levels.php
+++ b/includes/pmpro-gift-levels.php
@@ -52,8 +52,8 @@ function pmprowoo_gift_levels_add_recipient_fields() {
                 <td class="label"><label for="gift-recipient-email">'. esc_html__( 'Send Email to Recipient?', 'pmpro-woocommerce' ) . '</label></td>
                 <td class="value"><select id="pa_send-email" class="" name="gift-send-email"> 
                    <option selected="selected" value="">' . esc_html__( 'Choose an option', 'pmpro-woocommerce' ) . '</option>
-                   <option class="attached enabled" value="1">' . esc_html( 'YES', 'pmpro-woocommerce' ) . '</option>
-                   <option class="attached enabled" value="0">' . esc_html( 'NO', 'pmpro-woocommerce' ) . '</option>
+                   <option class="attached enabled" value="1">' . esc_html__( 'YES', 'pmpro-woocommerce' ) . '</option>
+                   <option class="attached enabled" value="0">' . esc_html__( 'NO', 'pmpro-woocommerce' ) . '</option>
                 </select></td>
                 </tr> 
                 <tr id="recipient-name" style="display:none;">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-woocomerce/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-woocomerce/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Two strings in pmpro-gift-levels.php can now be localized

### Changelog entry

Two strings in pmpro-gift-levels.php can now be localized
