### PR TITLE
BUG FIX: Add null guard for $pmprowoo_product_levels global

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -499,7 +499,15 @@ function pmprowoo_get_membership_price( $price, $product ) {
 	} else {
 		$product_id = $product->get_id();
 	}
-	
+
+	// Ensure the global is initialized before using it.
+	if ( ! is_array( $pmprowoo_product_levels ) ) {
+		$pmprowoo_product_levels = get_option( '_pmprowoo_product_levels' );
+		if ( empty( $pmprowoo_product_levels ) ) {
+			$pmprowoo_product_levels = array();
+		}
+	}
+
 	$membership_product_ids = array_keys( $pmprowoo_product_levels );
 	$items       = is_object( WC()->cart ) ? WC()->cart->get_cart_contents() : array(); // items in the cart
 


### PR DESCRIPTION
## Summary
Fixes a fatal error when the `$pmprowoo_product_levels` global is accessed before it's initialized.

## The Problem
The `pmprowoo_get_membership_price()` function is hooked to `woocommerce_product_get_price` and declares the global `$pmprowoo_product_levels`. It then calls `array_keys( $pmprowoo_product_levels )` without checking if the global has been initialized first.

The global is supposed to be set by `pmprowoo_init()` which runs on the `init` action. However, when other plugins (like WooCommerce Subscriptions) trigger cart/product operations early during `init`, the price filter can fire before `pmprowoo_init()` has run - leaving the global as `null`.

This results in a fatal error:
```
Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /wp-content/plugins/pmpro-woocommerce/pmpro-woocommerce.php:497
```

## The Fix
Added a null guard that checks if `$pmprowoo_product_levels` is an array before using it. If not, it loads the value from the option (matching the initialization pattern in `pmprowoo_init()`).

This ensures the global is always properly initialized when the function runs, regardless of hook execution order.

## Testing
- Install WooCommerce + WooCommerce Subscriptions
- Ensure PMPro WooCommerce is active with membership product levels configured
- The fatal error should no longer occur during cart/checkout operations

Fixes #208