### PR TITLE
Inherit pmpro-woocommerce options on multisite subsites

### DIFF
--- a/pmpro-woocommerce.php
+++ b/pmpro-woocommerce.php
@@ -65,6 +65,28 @@ function pmprowoo_init() {
 add_action( 'init', 'pmprowoo_init' );
 
 /**
+ * Register our option names with pmpro-network-subsite so that subsites in
+ * "inherit" mode read these settings from the main site.
+ *
+ * Requires a version of pmpro-network-subsite that exposes the
+ * pmpro_multisite_advanced_settings_options filter. On older versions this
+ * is a harmless no-op.
+ *
+ * @since TBD
+ *
+ * @param string[] $options Option names to inherit from the main site.
+ * @return string[]
+ */
+function pmprowoo_register_multisite_inherited_options( $options ) {
+	$options[] = '_pmprowoo_product_levels';
+	$options[] = '_pmprowoo_gift_codes';
+	$options[] = '_pmprowoo_member_discounts';
+	$options[] = 'pmpro_pmprowoo_discounts_on_subscriptions';
+	return $options;
+}
+add_filter( 'pmpro_multisite_advanced_settings_options', 'pmprowoo_register_multisite_inherited_options' );
+
+/**
  * Disable other membership products if a membership product is in the cart already
  *
  * @param bool        $is_purchasable


### PR DESCRIPTION
## Summary

Register the four pmpro-woocommerce option keys with pmpro-network-subsite's `pmpro_multisite_advanced_settings_options` filter so subsites running in "inherit" mode automatically read these settings from the main site:

- `_pmprowoo_product_levels`
- `_pmprowoo_gift_codes`
- `_pmprowoo_member_discounts`
- `pmpro_pmprowoo_discounts_on_subscriptions`

## Why

Resolves the original need from #114 (subsites unable to use main-site WooCommerce membership/discount settings).

Replaces #197, which manually backfilled these globals on `init:20`. That approach was written before pmpro-network-subsite added a centralized inheritance framework, had a bug in one of the option keys (`_pmprowoo_discounts_on_subscriptions` vs the canonical `pmpro_pmprowoo_discounts_on_subscriptions`), and called `is_plugin_active_for_network()` on the frontend `init` hook (the function is only available after `wp-admin/includes/plugin.php` is loaded, so it would fatal on the frontend).

This PR uses the existing pmpro-network-subsite mechanism, which:
- Respects the subsite admin's inherit/custom toggle.
- Reads option values via `pre_option_*` filters before any `get_option()` call, so the existing `pmprowoo_init()` flow needs no changes.
- Is a harmless no-op on older versions of pmpro-network-subsite that don't yet expose the filter.

## Test plan

- [ ] On a multisite network with pmpro-woocommerce per-site activated on a subsite and the main site, configure WooCommerce membership product levels and member discount pricing on the main site.
- [ ] Log in to a subsite (in inherit mode — the default), browse a WooCommerce product, confirm the member discount price is applied.
- [ ] Toggle the subsite to "custom" mode in pmpro-network-subsite's Advanced Settings and confirm subsite-local options take precedence again.
- [ ] Run on a single-site install — confirm no behavior change.
- [ ] Run with pmpro-network-subsite *not* installed — confirm no behavior change (filter is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
